### PR TITLE
Add support for method `NormalizeProperties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ResourceBase`
+  - Added a new method `NormalizeProperties` that can be overridden in a
+    derived class to provide custom normalization logic. This method can
+    be used to normalize the properties of a desired state prior to the
+    methods `AssertProperties`, `GetCurrentState`, and `Modify` being called.
+    Default there is no normalization of properties. Fixes [issue #27](https://github.com/dsccommunity/DscResource.Base/issues/27).
+
 ## [1.2.1] - 2025-02-03
 
 ### Changed
@@ -16,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Resource.Base`
+- `ResourceBase`
   - Add optional feature flag to handle using Enums as optional properties.
     This requires setting the starting value of the Enum to 1 so it is
     initialized as 0. Fixes [Issue #22](https://github.com/dsccommunity/DscResource.Base/issues/22).


### PR DESCRIPTION

#### Pull Request (PR) description

- `ResourceBase`
  - Added a new method `NormalizeProperties` that can be overridden in a
    derived class to provide custom normalization logic. This method can
    be used to normalize the properties of a desired state prior to the
    methods `AssertProperties`, `GetCurrentState`, and `Modify` being called.
    Default there is no normalization of properties. Fixes [issue #27](https://github.com/dsccommunity/DscResource.Base/issues/27).

#### This Pull Request (PR) fixes the following issues

- Fixes #27 


#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [x] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DscResource.Base/28)
<!-- Reviewable:end -->
