### PR TITLE
Add caching of properties not in desired state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `Get-DscProperty` when the property `FeatureOptionalEnums` is set to
     `$true`.
   - Remove calls to `Assert()` and `Normalize()` in `Test()` and `Set()` fixes [#35](https://github.com/dsccommunity/DscResource.Base/issues/35).
+  - Cache properties not in desired state.
+  - Make `Set()` call `Test()` and `Test()` call `Get()/Compare()`.
 
 ### Fixed
 

--- a/source/Classes/010.ResourceBase.ps1
+++ b/source/Classes/010.ResourceBase.ps1
@@ -19,6 +19,9 @@ class ResourceBase
     # Property for derived class to set properties that should not be enforced.
     hidden [System.String[]] $ExcludeDscProperties = @()
 
+    # Property for holding the properties that are not in desired state.
+    hidden [System.Collections.Hashtable[]] $PropertiesNotInDesiredState = @()
+
     # Property for derived class to enable Enums to be used as optional properties. The usable Enum values should start at value 1.
     hidden [System.Boolean] $FeatureOptionalEnums = $false
 
@@ -117,7 +120,7 @@ class ResourceBase
             Returns all enforced properties not in desired state, or $null if
             all enforced properties are in desired state.
         #>
-        $propertiesNotInDesiredState = $this.Compare($getCurrentStateResult, @())
+        $this.PropertiesNotInDesiredState = $this.Compare($getCurrentStateResult, @())
 
         <#
             Return the correct values for Reasons property if the derived DSC resource
@@ -126,7 +129,7 @@ class ResourceBase
         if (($this | Test-DscProperty -Name 'Reasons') -and -not $getCurrentStateResult.ContainsKey('Reasons'))
         {
             # Always return an empty array if all properties are in desired state.
-            $dscResourceObject.Reasons = $propertiesNotInDesiredState |
+            $dscResourceObject.Reasons = $this.PropertiesNotInDesiredState |
                 Resolve-Reason -ResourceName $this.GetType().Name |
                 ConvertFrom-Reason
         }
@@ -142,31 +145,24 @@ class ResourceBase
 
         Write-Verbose -Message ($this.localizedData.SetDesiredState -f $this.GetType().Name, ($keyProperty | ConvertTo-Json -Compress))
 
-        <#
-            Returns all enforced properties not in desires state, or $null if
-            all enforced properties are in desired state.
-        #>
-        $propertiesNotInDesiredState = $this.Compare()
-
-        if ($propertiesNotInDesiredState)
-        {
-            $propertiesToModify = $propertiesNotInDesiredState | ConvertFrom-CompareResult
-
-            $propertiesToModify.Keys |
-                ForEach-Object -Process {
-                    Write-Verbose -Message ($this.localizedData.SetProperty -f $_, $propertiesToModify.$_)
-                }
-
-            <#
-                Call the Modify() method with the properties that should be enforced
-                and are not in desired state.
-            #>
-            $this.Modify($propertiesToModify)
-        }
-        else
+        if ($this.Test())
         {
             Write-Verbose -Message $this.localizedData.NoPropertiesToSet
+            return
         }
+
+        $propertiesToModify = $this.PropertiesNotInDesiredState | ConvertFrom-CompareResult
+
+        $propertiesToModify.Keys |
+            ForEach-Object -Process {
+                Write-Verbose -Message ($this.localizedData.SetProperty -f $_, $propertiesToModify.$_)
+            }
+
+        <#
+            Call the Modify() method with the properties that should be enforced
+            and are not in desired state.
+        #>
+        $this.Modify($propertiesToModify)
     }
 
     [System.Boolean] Test()
@@ -181,9 +177,9 @@ class ResourceBase
             all enforced properties are in desired state.
             Will call Get().
         #>
-        $propertiesNotInDesiredState = $this.Compare()
+        $this.PropertiesNotInDesiredState = $this.Compare()
 
-        if ($propertiesNotInDesiredState)
+        if ($this.PropertiesNotInDesiredState)
         {
             Write-Verbose -Message $this.localizedData.NotInDesiredState
             return $false


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure the PR title is short but a descriptive
    summary of the PR,
    e.g "String arrays where not allowed if it had un unsupported value map".

    You may remove this comment block, and the other comment blocks,
    but please keep the headers and the task list.
-->
#### Pull Request (PR) description
<!--
    Replace this comment block with a description of your PR.
-->

Cache properties not in desired state.
Make `Set()` call `Test()` and `Test()` call `Get()/Compare()`.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment block with the list of issues or n/a.
Use format:
- Fixes #123
- Fixes #124
-->

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
